### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,7 @@
 name: Build Robotics Docs
 on: [push]
+permissions:
+  contents: write
 
 jobs:
   docs:


### PR DESCRIPTION
Potential fix for [https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/6](https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the required permissions. Based on the workflow's steps:
1. The `actions/checkout@v4` step requires `contents: read` to check out the repository.
2. The `actions/upload-artifact@v3` step requires `contents: read` to access files and `contents: write` to upload artifacts.

We will set these permissions at the workflow level to apply them to all jobs, as no job-specific permissions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
