### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -1,4 +1,6 @@
 name: Update Diagrams
+permissions:
+  contents: write
 on:
   push:
      paths:


### PR DESCRIPTION
Potential fix for [https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/7](https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves pushing changes to the repository, it requires `contents: write`. Other permissions, such as `contents: read`, are not necessary for this workflow.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs in the workflow. This ensures that the `GITHUB_TOKEN` used in the workflow has the appropriate permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
