### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/2](https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow interacts with the repository's contents (e.g., committing and pushing changes), it requires `contents: write` permission. We will explicitly define this permission at the job level to limit its scope to the `update` job. This ensures the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
