### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
   supercharge-profile:
     name: ⚡ Actualización Dinámica
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Paso 1: Checkout mágico
       - name: 🛸 Clonar Repo


### PR DESCRIPTION
Potential fix for [https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/19](https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/19)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the job. Since the job pushes changes to the repository, it needs `contents: write`. Other permissions can be omitted or set to `none` (the default is `none` for unspecified permissions). The best way to fix this is to add the following under the job definition (`supercharge-profile`):  
```yaml
permissions:
  contents: write
```
This should be added as a sibling to `runs-on` (i.e., at the same indentation level as `runs-on` and `name` under the job). No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
