### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,9 @@ name: MechMind Quality Gate
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/29](https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/29)

To fix the problem, we should add an explicit `permissions` block to limit the default permissions of the `GITHUB_TOKEN` used by this workflow. Since none of the steps modify repository contents or require elevated privileges, `contents: read` is a safe minimal setting that allows the workflow to read the repository but not make changes. This should be added near the top of the workflow (either at the root or under the relevant job). Placing it at the root will apply it to all jobs (in this case, there is only one job), providing clarity and maintainability.

Specifically, in `.github/workflows/coverage.yml`, after the `name` and `on` keys but before the `jobs` key, add:
```yaml
permissions:
  contents: read
```
No further methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
