### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,4 +1,6 @@
 name: "🦀 Rust Super Pipeline"
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/21](https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/21)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/rust-ci.yml`. The block should be placed at the root level (just below the `name` and before `on` or `jobs`), so it applies to all jobs unless overridden. For this workflow, the jobs only need to read repository contents (for checkout and running tests), so the minimal required permission is `contents: read`. If any job needs additional permissions (e.g., uploading artifacts, creating issues, etc.), those can be added, but based on the provided code, only `contents: read` is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
