### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:       # Trigger manual
 
+permissions:
+  contents: write
+
 jobs:
   supercharge-profile:
     name: ⚡ Actualización Dinámica


### PR DESCRIPTION
Potential fix for [https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/28](https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/28)

**How to fix generically:**  
Add an explicit `permissions` key with the minimal required scopes at the top-level of the workflow or at the job level for any jobs requiring elevated permissions. For jobs that only read repo data, set to `contents: read`. For jobs that do writing (such as pushing to the repo), set `contents: write`. Add any other permissions only as truly necessary.

**Single best fix without changing functionality:**  
- Add a `permissions:` block to the root of the workflow, before `jobs:`.
- Set to `contents: write` since the workflow needs to push commits in "supercharge-profile", and this will propagate to all jobs unless overridden.
- For jobs that do not need `write` access (e.g., if `deploy-mechbot` only builds and deploys, not pushes), you could optionally restrict with a per-job `permissions` block, but propagate root-level is already least-privilege for your jobs here.
- No other permissions are obviously required (`pull-requests`, `issues`, etc.) from the visible logic.

**Edits to make:**  
- Insert the following at line 8 (after triggers, before `jobs:`):

    ```yaml
    permissions:
      contents: write
    ```

**Dependencies needed:**  
None.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
