### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: MechMind Quality Gate
 
 on: push


### PR DESCRIPTION
Potential fix for [https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/30](https://github.com/mechmind-dwv/mechmind-dwv/security/code-scanning/30)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code, install dependencies, run scans, run tests, and upload artifacts, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read repository contents. This block should be added at the top level of the workflow (just after the `name` and before `on`), so it applies to all jobs unless overridden.

**Steps:**
- Edit `.github/workflows/quality-gate.yml`.
- Add the following block after the `name` line and before the `on` line:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
